### PR TITLE
Update: include initializers path in tailwind.config.js

### DIFF
--- a/lib/generators/simple_form/tailwind/install_generator.rb
+++ b/lib/generators/simple_form/tailwind/install_generator.rb
@@ -8,6 +8,28 @@ module SimpleForm
       desc 'Generate a SimpleForm config for tailwind based forms'
       source_root File.expand_path('templates', __dir__)
 
+      def update_tailwind_config
+        # Open the tailwind.config.js file
+        config_path = Rails.root.join('config/tailwind.config.js')
+        if File.exist?(config_path)
+          # Read the existing file
+          config = File.read(config_path)
+          # Add the line in the content section if it's not already there
+          if config.include?('./config/initializers')
+            say "tailwind.config.js already includes the necessary configuration.", :green
+          else
+            config.sub!('content: [', "content: [\n    \"./config/initializers/*.rb\",")
+            # save modifications
+            File.write(config_path, config)
+            say "tailwind.config.js has been updated with the necessary configuration.", :green
+          end
+        else
+          say "tailwind.config.js not found.", :red
+          say "Please ensure Tailwind is properly installed and try again.", :yellow
+          exit # Cancel installation
+        end
+      end
+
       def copy_initialzier
         copy_file('simple_form.rb', 'config/initializers/simple_form_tailwind.rb', force: true)
       end


### PR DESCRIPTION
This pull request includes a significant update to the `InstallGenerator` class in the `lib/generators/simple_form/tailwind/install_generator.rb` file. The main change involves adding a method to update the Tailwind CSS configuration file.

### Enhancements to Tailwind CSS configuration:

* [`lib/generators/simple_form/tailwind/install_generator.rb`](diffhunk://#diff-170d4a5a8b40e9b4fc2e2d168175c82a9d21fa4fd5ed7c2bdc6c7d221abc5f1aR11-R32): Added the `update_tailwind_config` method to check for the existence of `tailwind.config.js`, read its content, and update the content section to include `./config/initializers/*.rb` if it is not already present. This ensures that the necessary configuration for simple_form-tailwind is in place.

Fixes #10